### PR TITLE
Use `removeChild` instead of `remove`.

### DIFF
--- a/particles.js
+++ b/particles.js
@@ -597,7 +597,9 @@ function launchParticlesJS(tag_id, params){
 
   pJS.fn.vendors.destroy = function(){
     cancelAnimationFrame(pJS.fn.requestAnimFrame);
-    canvas_el.remove();
+    if (canvas_el.parentNode) {
+      canvas_el.parentNode.removeChild(canvas_el);
+    }
     pJS = null;
   };
 


### PR DESCRIPTION
IE does not support `element.remove`.

Fixes a minor error in IE in Jaguar.
